### PR TITLE
Use scroll wheel to change language and view command history

### DIFF
--- a/index.html
+++ b/index.html
@@ -2790,6 +2790,15 @@
             }
         });
 
+        languageButton.addEventListener('wheel', (e) => {
+            e.preventDefault();
+            const currentIndex = languageOrder.indexOf(currentLanguage);
+            const newIndex = e.deltaY < 0 
+                ? (currentIndex > 0 ? currentIndex - 1 : languageOrder.length - 1)
+                : (currentIndex < languageOrder.length - 1 ? currentIndex + 1 : 0);
+            switchLanguage(languageOrder[newIndex]);
+        });
+
         dropdownBackdrop.addEventListener('click', () => {
             closeLangPicker();
         });
@@ -3619,6 +3628,45 @@
                 return;
             }
             
+        });
+
+        codeInput.addEventListener('wheel', (e) => {
+            if (codeHistory.length === 0) return;
+            e.preventDefault();
+            
+            if (e.deltaY < 0) {
+                // Scroll up - go to previous (older) history entry
+                if (historyIndex === -1) {
+                    currentUnsavedCode = getInputText();
+                    historyIndex = codeHistory.length;
+                    
+                    if (codeHistory[codeHistory.length - 1] === currentUnsavedCode.trim()) {
+                        historyIndex--;
+                    }
+                }
+                
+                if (historyIndex > 0) {
+                    historyIndex--;
+                    setInputText(codeHistory[historyIndex]);
+                    editorFeatures.handleAutoExpand();
+                    hideOutput();
+                }
+            } else {
+                // Scroll down - go to next (newer) history entry
+                if (historyIndex === -1) return;
+                
+                historyIndex++;
+                
+                if (historyIndex >= codeHistory.length) {
+                    historyIndex = -1;
+                    setInputText(currentUnsavedCode);
+                    currentUnsavedCode = '';
+                } else {
+                    setInputText(codeHistory[historyIndex]);
+                }
+                editorFeatures.handleAutoExpand();
+                hideOutput();
+            }
         });
 
         // Track IME/Compose key composition state to avoid disrupting input


### PR DESCRIPTION
Added a couple of things:

- When you hover over the language logo, scrolling up or down with a scroll wheel will change the logo, language and translation.
- If you've typed a few lines, you can hover over the code input and scroll through the code history.

After playing with this feature for a while, I noticed that if you have a large output and then scroll the command history, your mouse may not be over the code input textbox anymore when the output is removed. I'm not a user interface person, but I felt I should mention it.